### PR TITLE
changed the construction of the morse graph

### DIFF
--- a/src/dsgrn_net_query/queries/CountFPMatch.py
+++ b/src/dsgrn_net_query/queries/CountFPMatch.py
@@ -147,8 +147,7 @@ def DSGRN_Computation(parameter):
     :return: list of DSGRN annotations
     '''
     dg = DSGRN.DomainGraph(parameter)
-    md = DSGRN.MorseDecomposition(dg.digraph())
-    mg = DSGRN.MorseGraph(dg, md)
+    mg = DSGRN.MorseGraph(dg)
     return [mg.annotation(i)[0] for i in range(0, mg.poset().size()) if is_FP(mg.annotation(i)[0]) and len(mg.poset(
         ).children(i)) == 0]
 

--- a/src/dsgrn_net_query/queries/CountPatternMatch.py
+++ b/src/dsgrn_net_query/queries/CountPatternMatch.py
@@ -281,6 +281,29 @@ def domain_check(domaingraph,patterngraph):
     return ismatch
 
 
+# def stableFC_check_buggy(domaingraph,patterngraph,paramind):
+#     # Note: morsegraph.poset().stringify != morsedecomposition.poset().stringify in all cases.
+#     '''
+#     Check for match in any stable full cycle for one parameter
+#     :param domaingraph: DSGRN domain graph object
+#     :param patterngraph: DSGRN pattern graph object
+#     :return: True or False for the existence of a match and True or False for the existence of a stable full cycle
+#     '''
+#     FC = False
+#     ismatch = False
+#     morsedecomposition = DSGRN.MorseDecomposition(domaingraph.digraph())
+#     morsegraph = DSGRN.MorseGraph(domaingraph, morsedecomposition)
+#     for i in range(0, morsegraph.poset().size()):
+#         if morsegraph.annotation(i)[0] == "FC" and len(morsedecomposition.poset().children(i)) == 0:
+#             FC = True
+#             searchgraph = DSGRN.SearchGraph(domaingraph, i)
+#             matchinggraph = DSGRN.MatchingGraph(searchgraph, patterngraph)
+#             if DSGRN.PathMatch(matchinggraph):
+#                 ismatch = True
+#                 break
+#     return ismatch,FC
+
+
 def stableFC_check(domaingraph,patterngraph):
     '''
     Check for match in any stable full cycle for one parameter
@@ -290,10 +313,9 @@ def stableFC_check(domaingraph,patterngraph):
     '''
     FC = False
     ismatch = False
-    morsedecomposition = DSGRN.MorseDecomposition(domaingraph.digraph())
-    morsegraph = DSGRN.MorseGraph(domaingraph, morsedecomposition)
-    for i in range(0, morsedecomposition.poset().size()):
-        if morsegraph.annotation(i)[0] == "FC" and len(morsedecomposition.poset().children(i)) == 0:
+    morsegraph = DSGRN.MorseGraph(domaingraph)
+    for i in range(0, morsegraph.poset().size()):
+        if morsegraph.annotation(i)[0] == "FC" and len(morsegraph.poset().children(i)) == 0:
             FC = True
             searchgraph = DSGRN.SearchGraph(domaingraph, i)
             matchinggraph = DSGRN.MatchingGraph(searchgraph, patterngraph)

--- a/src/dsgrn_net_query/queries/CountPatternMatch_large_networks.py
+++ b/src/dsgrn_net_query/queries/CountPatternMatch_large_networks.py
@@ -261,10 +261,9 @@ def stableFC_check(domaingraph,patterngraph):
     '''
     FC = False
     ismatch = False
-    morsedecomposition = DSGRN.MorseDecomposition(domaingraph.digraph())
-    morsegraph = DSGRN.MorseGraph(domaingraph, morsedecomposition)
-    for i in range(0, morsedecomposition.poset().size()):
-        if morsegraph.annotation(i)[0] == "FC" and len(morsedecomposition.poset().children(i)) == 0:
+    morsegraph = DSGRN.MorseGraph(domaingraph)
+    for i in range(0, morsegraph.poset().size()):
+        if morsegraph.annotation(i)[0] == "FC" and len(morsegraph.poset().children(i)) == 0:
             FC = True
             searchgraph = DSGRN.SearchGraph(domaingraph, i)
             matchinggraph = DSGRN.MatchingGraph(searchgraph, patterngraph)

--- a/src/dsgrn_net_query/queries/CountStableFC.py
+++ b/src/dsgrn_net_query/queries/CountStableFC.py
@@ -92,8 +92,7 @@ def search_over_networks(count,N,enum_network):
     for p in range(parametergraph.size()):
         parameter = parametergraph.parameter(p)
         dg = DSGRN.DomainGraph(parameter)
-        md = DSGRN.MorseDecomposition(dg.digraph())
-        mg = DSGRN.MorseGraph(dg, md)
+        mg = DSGRN.MorseGraph(dg)
         stable_FC_annotations = [mg.annotation(i)[0] for i in range(0, mg.poset().size())
                                  if is_FC(mg.annotation(i)[0]) and len(mg.poset().children(i)) == 0]
         if count and len(stable_FC_annotations) > 0:

--- a/tests/test_patternmatch.py
+++ b/tests/test_patternmatch.py
@@ -65,10 +65,12 @@ def test_patternmatch3():
     qdir = subprocess.check_output("tail -n 1 dsgrn_net_query.log",shell=True).strip().decode("utf-8")
     output_file2 = os.path.join(qdir,"query_results_stablefc_no_time_series_file.json")
     results2 = json.load(open(output_file2))
+    print(results2)
     assert (results2 == {
-        'X1 : (X1)(~X3) : E\nX2 : (X1 + X3) : E\nX3 : (X1 + X2) : E\n': [[0.0, 205, 532, 2352], [0.1, 317, 532, 2352]],
-        'X1 : (X1)(~X3) : E\nX2 : (X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 40, 74, 168], [0.1, 54, 74, 168]],
-        'X1 : (X1)(~X3) : E\nX2 : (X3)(~X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 0, 299, 2352], [0.1, 0, 299, 2352]]})
+        'X1 : (X1)(~X3) : E\nX2 : (X3)(~X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 0, 152, 2352], [0.1, 0, 152, 2352]],
+         'X1 : (X1)(~X3) : E\nX2 : (X1 + X3) : E\nX3 : (X1 + X2) : E\n': [[0.0, 205, 500, 2352], [0.1, 317, 500, 2352]],
+         'X1 : (X1)(~X3) : E\nX2 : (X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 40, 76, 168], [0.1, 54, 76, 168]]
+    })
     subprocess.call(["rm","-r", "temp_results/"])
 
 
@@ -137,10 +139,11 @@ def test_patternmatch_ln3():
     output_file2 = os.path.join(qdir,"query_results_stablefc_no_time_series_file.json")
     results2 = json.load(open(output_file2))
     assert (results2 == {
-        'X1 : (X1)(~X3) : E\nX2 : (X1 + X3) : E\nX3 : (X1 + X2) : E\n': [[0.0, 205, 532, 2352], [0.1, 317, 532, 2352]],
-        'X1 : (X1)(~X3) : E\nX2 : (X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 40, 74, 168], [0.1, 54, 74, 168]],
-        'X1 : (X1)(~X3) : E\nX2 : (X3)(~X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 0, 299, 2352], [0.1, 0, 299, 2352]]})
+        'X1 : (X1)(~X3) : E\nX2 : (X3)(~X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 0, 152, 2352], [0.1, 0, 152, 2352]],
+         'X1 : (X1)(~X3) : E\nX2 : (X1 + X3) : E\nX3 : (X1 + X2) : E\n': [[0.0, 205, 500, 2352], [0.1, 317, 500, 2352]],
+         'X1 : (X1)(~X3) : E\nX2 : (X1) : E\nX3 : (X1 + X2) : E\n': [[0.0, 40, 76, 168], [0.1, 54, 76, 168]]
+})
     subprocess.call(["rm","-r", "temp_results/"])
 
 if __name__ == "__main__":
-    test_patternmatch_ln3()
+    test_patternmatch3()


### PR DESCRIPTION
The Morse graph was previously constructed using the Morse decomposition, and is now constructed solely from the domain graph.

During the course of this process, a major bug was uncovered. Previously, annotations for FC were assessed using the MG and stability was assessed using the MD. Unfortunately the indexing of the Morse sets between the two is not always consistent. This led to a miscounting of FCs. The fix is to always use the Morse graph. This bug did not affect fixed points, since their stability was not assessed. 